### PR TITLE
兼容antd2以及babel 6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,6 +63,7 @@ typings/
 .npmrc
 /packages/rrc-loader-helper/lib
 /packages/react-router/lib
+/packages/create-react-context/lib
 lerna-debug.log
 
 dist/

--- a/packages/create-react-context/.eslintrc
+++ b/packages/create-react-context/.eslintrc
@@ -1,0 +1,15 @@
+{
+  "extends": "airbnb",
+  "rules": {
+    "comma-dangle": "off",
+    "prefer-template": "off",
+    "react/jsx-filename-extension": "off",
+    "no-console": "off",
+    "import/no-unresolved": "off",
+    "no-param-reassign": "off"
+  },
+  "env": {
+    "jest": true,
+    "browser": true
+  }
+}

--- a/packages/create-react-context/package.json
+++ b/packages/create-react-context/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@vve/create-react-context",
+  "version": "1.0.0",
+  "peerDependencies": {
+    "react": ">=15"
+  },
+  "files": [
+    "lib/**"
+  ],
+  "main": "lib/index.js",
+  "scripts": {
+    "build": "babel src --out-dir lib"
+  }
+}

--- a/packages/create-react-context/src/index.js
+++ b/packages/create-react-context/src/index.js
@@ -1,0 +1,157 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import gud from 'gud';
+import warning from 'tiny-warning';
+
+const MAX_SIGNED_31_BIT_INT = 1073741823;
+
+// Inlined Object.is polyfill.
+// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/is
+function objectIs(x, y) {
+  if (x === y) {
+    return x !== 0 || 1 / x === 1 / y;
+  }
+  return x !== x && y !== y;
+}
+
+
+function createEventEmitter(value) {
+  let handlers = [];
+  return {
+    on(handler) {
+      handlers.push(handler);
+    },
+
+    off(handler) {
+      handlers = handlers.filter(h => h !== handler);
+    },
+
+    get() {
+      return value;
+    },
+
+    set(newValue, changedBits) {
+      value = newValue;
+      handlers.forEach(handler => handler(value, changedBits));
+    }
+  };
+}
+
+function onlyChild(children) {
+  return Array.isArray(children) ? children[0] : children;
+}
+
+export default function createReactContext(defaultValue, calculateChangedBits) {
+  const contextProp = '__create-react-context-' + gud() + '__';
+
+  class Provider extends Component {
+    constructor(props) {
+      super(props);
+      this.emitter = createEventEmitter(this.props.value);
+    }
+
+    getChildContext() {
+      return {
+        [contextProp]: this.emitter
+      };
+    }
+
+    componentWillReceiveProps(nextProps) {
+      if (this.props.value !== nextProps.value) {
+        const oldValue = this.props.value;
+        const newValue = nextProps.value;
+        let changedBits = 0;
+
+        if (objectIs(oldValue, newValue)) {
+          changedBits = 0; // No change
+        } else {
+          changedBits = typeof calculateChangedBits === 'function'
+            ? calculateChangedBits(oldValue, newValue)
+            : MAX_SIGNED_31_BIT_INT;
+          if (process.env.NODE_ENV !== 'production') {
+            warning(
+              (changedBits & MAX_SIGNED_31_BIT_INT) === changedBits,
+              'calculateChangedBits: Expected the return value to be a '
+              + '31-bit integer. Instead received: ' + changedBits,
+            );
+          }
+
+          changedBits |= 0;
+
+          if (changedBits !== 0) {
+            this.emitter.set(nextProps.value, changedBits);
+          }
+        }
+      }
+    }
+
+    render() {
+      return this.props.children;
+    }
+  }
+
+  Provider.childContextTypes = {
+    [contextProp]: PropTypes.object.isRequired
+  };
+
+  class Consumer extends Component {
+    constructor(props) {
+      super(props);
+      this.state = {
+        value: this.getValue()
+      };
+      this.observedBits = 0;
+      this.onUpdate = (newValue, changedBits) => {
+        const observedBits = this.observedBits | 0;
+        if ((observedBits & changedBits) !== 0) {
+          this.setState({ value: this.getValue() });
+        }
+      };
+    }
+
+
+    componentDidMount() {
+      if (this.context[contextProp]) {
+        this.context[contextProp].on(this.onUpdate);
+      }
+      const { observedBits } = this.props;
+      this.observedBits = observedBits === undefined || observedBits === null
+        ? MAX_SIGNED_31_BIT_INT // Subscribe to all changes by default
+        : observedBits;
+    }
+
+
+    componentWillReceiveProps(nextProps) {
+      const { observedBits } = nextProps;
+      this.observedBits = observedBits === undefined || observedBits === null
+        ? MAX_SIGNED_31_BIT_INT // Subscribe to all changes by default
+        : observedBits;
+    }
+
+    componentWillUnmount() {
+      if (this.context[contextProp]) {
+        this.context[contextProp].off(this.onUpdate);
+      }
+    }
+
+    getValue() {
+      if (this.context[contextProp]) {
+        return this.context[contextProp].get();
+      }
+      return defaultValue;
+    }
+
+    render() {
+      return onlyChild(this.props.children)(this.state.value);
+    }
+  }
+
+  Consumer.contextTypes = {
+    [contextProp]: PropTypes.object
+  };
+
+  return {
+    Provider,
+    Consumer
+  };
+}

--- a/packages/react-redux-component-loader/lib/babel-plugin-store-transform.js
+++ b/packages/react-redux-component-loader/lib/babel-plugin-store-transform.js
@@ -116,7 +116,7 @@ module.exports = function BabelPluginStoreTransform(babel) {
 
         if (!shouldGen) return;
         programPath.node.body.unshift(cacheFnPartial({
-          JSON: t.StringLiteral('JSON'),
+          JSON: t.Identifier('JSON'),
         }));
         programPath.scope.getBinding('store').referencePaths.forEach((pt) => {
           if (!pt.findParent(p => doneState.doneFunction.has(p.node))) {

--- a/packages/react-redux-component-loader/lib/babel-plugin-store-transform.js
+++ b/packages/react-redux-component-loader/lib/babel-plugin-store-transform.js
@@ -19,7 +19,7 @@ module.exports = function BabelPluginStoreTransform(babel) {
   const { types: t, template: temp } = babel;
   const consumerFnTemp = temp(`(currentPage) => { const store = ${rawStoreVariable}['.__inner__'].setCurrentPage(currentPage);}\n`);
   const storeVarTemp = temp(`const store = ${rawStoreVariable}['.__inner__'].setCurrentPage(this.ThePageContext);\n`);
-  const cacheFnPartial = temp.ast(`function cacheFnPartial_(fn, arg) {
+  const cacheFnPartial = temp(`function cacheFnPartial_(fn, arg) {
   fn.cacheMap = fn.cacheMap || new Map();
   const key = JSON.stringify(arg);
   if (!fn.cacheMap.has(key)) {
@@ -115,7 +115,9 @@ module.exports = function BabelPluginStoreTransform(babel) {
         }, doneState);
 
         if (!shouldGen) return;
-        programPath.node.body.unshift(cacheFnPartial);
+        programPath.node.body.unshift(cacheFnPartial({
+          JSON: t.StringLiteral('JSON'),
+        }));
         programPath.scope.getBinding('store').referencePaths.forEach((pt) => {
           if (!pt.findParent(p => doneState.doneFunction.has(p.node))) {
             const fnParent = pt.getFunctionParent();

--- a/packages/react-router/package.json
+++ b/packages/react-router/package.json
@@ -27,7 +27,7 @@
     "url": "https://github.com/sheinsight/react-router/ssues"
   },
   "dependencies": {
-    "create-react-context": "^0.2.3",
+    "@vve/create-react-context": "^1.0.0",
     "path-to-regexp": "^3.0.0",
     "tiny-invariant": "^1.0.4",
     "tiny-warning": "^1.0.2"

--- a/packages/rrc-loader-helper/package.json
+++ b/packages/rrc-loader-helper/package.json
@@ -32,7 +32,7 @@
     "@babel/runtime": "^7.1.5",
     "@vve/react-router": "^6.2.1-alpha.8",
     "@vve/redux-saga": "^6.2.1-alpha.2",
-    "create-react-context": "^0.2.3",
+    "@vve/create-react-context": "^1.0.0",
     "gud": "^1.0.0",
     "immer": "^1.7.4",
     "react-lifecycles-compat": "^3.0.4",


### PR DESCRIPTION
1. antd2的版本，Modal中使用了unstable_renderxXXX，这货与16.3引入的context API的配合有问题，因此将create-react-context降级为只使用legacy context
2. 之前的版本使用了babel7中才有的template.ast，撤销之